### PR TITLE
Livestream page fixes

### DIFF
--- a/src/components/Livestream/Livestream.jsx
+++ b/src/components/Livestream/Livestream.jsx
@@ -28,7 +28,7 @@ function LiveStream() {
         <Fade left={isDesktop} bottom={isMobile} duration={1000} delay={1000} distance="30px">
           <iframe
             title="livestream"
-            src={`https://player.twitch.tv/?channel=naadisaeedyes&parent=${process.env.GATSBY_PARENT_URL}&autoplay=true`}
+            src={`https://player.twitch.tv/?channel=naadisaeedyes&parent=${process.env.GATSBY_PARENT_URL}&parent=www.${process.env.GATSBY_PARENT_URL}&autoplay=true`}
             height={isDesktop ? '720' : '100%'}
             width={isDesktop ? '1280' : '100%'}
             frameBorder="0"

--- a/src/components/Livestream/Livestream.jsx
+++ b/src/components/Livestream/Livestream.jsx
@@ -29,8 +29,8 @@ function LiveStream() {
           <iframe
             title="livestream"
             src={`https://player.twitch.tv/?channel=naadisaeedyes&parent=${process.env.GATSBY_PARENT_URL}&autoplay=true`}
-            height="720"
-            width="1280"
+            height={isDesktop ? '720' : '100%'}
+            width={isDesktop ? '1280' : '100%'}
             frameBorder="0"
             scrolling="no"
             allowFullScreen="true"


### PR DESCRIPTION
Two fixes for the livestream page:
1 - Resolve the error `Refused to frame ‘https://player.twitch.tv/’ because an ancestor violates the following Content Security Policy directive: “frame-ancestors”` by adding an additional parent parameter to the embedded stream that contains the domain with the www prefix. Solution found from: https://discuss.dev.twitch.tv/t/refused-to-frame-https-player-twitch-tv-because-an-ancestor-violates-the-following-content-security-policy-directive-frame-ancestors/26820
2 - Resolved height and width of player to be reactive of if the browser is Desktop or Mobile